### PR TITLE
create-another-cache

### DIFF
--- a/environments/ci/docker-compose.yaml
+++ b/environments/ci/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   core:
-    image: ci
+    image: ci-test
     build:
       args:
         - BASE_IMAGE=ubuntu:20.04


### PR DESCRIPTION
When creating this pull request, build cache exists on the merge branch.
Upon creating the pull request, the `lint-and-test` workflow does not use the existing cache, as one of the environment-related files (`environments/Dockerfile`, `environments/ci/docker-compose.yaml`, or `poetry.lock`) has changed.
Upon merging the pull request, a new cache is created on the `cache-BuildCache-only` branch, which is the base branch.

## Workflows after merge

- `lint-and-test` workflow: build images without cache; take **1 m 35 s** to finish the workflow
- `cache` workflow: build images to create the new build cache

![image](https://github.com/YoshikiKubotani/AscenderTest/assets/61688218/e6ceb31b-91a5-449c-9601-86b5dbba8a70)

## Caches after merge

the new cache is created on `cache-BuildCache-only` branch (=base branch) by `cache` workflow

![image](https://github.com/YoshikiKubotani/AscenderTest/assets/61688218/39c02dd3-4d6a-4267-9b51-cf40c6976790)
